### PR TITLE
adding jinja2 as a requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ url = "https://dp2-prod.appspot.com/pypi"
 
 [tool.poetry]
 name = "cloudalerts"
-version = "0.0.1"
+version = "0.0.2"
 description = "Python tool for accessing mozilla cloud alerting services."
 authors = [
     "Adam Frank <afrank@mozilla.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 python = ">=3.7"
 google-cloud-logging = "*"
 tox = "*"
+jinja2 = "^2.11.2"
 
 [tool.poetry.dev-dependencies]
 pre-commit = "*"


### PR DESCRIPTION
I'm just building my gcp_billing_alerts package and fixing downstream problems as I see 'em