### PR TITLE
Init loading correction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ url = "https://dp2-prod.appspot.com/pypi"
 
 [tool.poetry]
 name = "cloudalerts"
-version = "0.0.4"
+version = "0.0.5"
 description = "Python tool for accessing mozilla cloud alerting services."
 authors = [
     "Adam Frank <afrank@mozilla.com>",

--- a/tests/unit/cloudalerts/v1/__init__.py
+++ b/tests/unit/cloudalerts/v1/__init__.py
@@ -1,8 +1,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-from .alert_logging import AlertLogger
-from .cloud_logging import CloudLogging
-
-__all__ = ["AlertLogger", "CloudLogging"]

--- a/tests/unit/cloudalerts/v1/loggers/__init__.py
+++ b/tests/unit/cloudalerts/v1/loggers/__init__.py
@@ -1,8 +1,3 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-from .alert_logging import AlertLogger
-from .cloud_logging import CloudLogging
-
-__all__ = ["AlertLogger", "CloudLogging"]

--- a/tests/unit/cloudalerts/v1/loggers/test_init.py
+++ b/tests/unit/cloudalerts/v1/loggers/test_init.py
@@ -2,7 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-from .alert_logging import AlertLogger
-from .cloud_logging import CloudLogging
 
-__all__ = ["AlertLogger", "CloudLogging"]
+def test__init__():
+    from cloudalerts.v1.loggers import __all__
+
+    expected = ["AlertLogger", "CloudLogging"]
+    assert expected == __all__


### PR DESCRIPTION
This pull request (PR) corrects an issue from the merge in which the CloudLogger module was dropped (presumably by PyCharm) and missed in code review.  I caught it in a downstream test application.  A unit test was added to catch this in the future which improves the code coverage significantly.

```
py37 run-test: commands[2] | coverage report -m '--omit=*/test*,.tox/*' --show-missing --fail-under=45
Name                                      Stmts   Miss Branch BrPart     Cover   Missing
----------------------------------------------------------------------------------------
cloudalerts/__init__.py                       1      0      0      0   100.00%
cloudalerts/v1/__init__.py                    0      0      0      0   100.00%
cloudalerts/v1/alerts/__init__.py             1      0      0      0   100.00%
cloudalerts/v1/alerts/alert_utils.py         41     25      4      0    35.56%   18-19, 23-25, 29-30, 34-35, 41-46, 55-64, 75-85
cloudalerts/v1/loggers/__init__.py            1      0      0      0   100.00%
cloudalerts/v1/loggers/alert_logging.py      30     15      2      0    46.88%   16-17, 29-36, 59-61, 64-66, 69
cloudalerts/v1/loggers/cloud_logging.py       2      0      0      0   100.00%
cloudalerts/v2/__init__.py                    0      0      0      0   100.00%
cloudalerts/v2/alerts/__init__.py             0      0      0      0   100.00%
cloudalerts/v2/alerts/alert_utils.py         26      3      2      1    85.71%   21, 40->41, 41-42
cloudalerts/v2/loggers/__init__.py            0      0      0      0   100.00%
cloudalerts/v2/loggers/log_filter.py         16      1     16      2    90.62%   15->16, 16, 19->18
cloudalerts/v2/loggers/structlog.py          21     17      2      0    17.39%   24-44, 85-87, 91-100
----------------------------------------------------------------------------------------
TOTAL                                       139     61     26      3    56.36%

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-it/cloudalerts/30)
<!-- Reviewable:end -->
