### PR TITLE
Mozilla Security Operations, top level headers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,12 +12,14 @@ repos:
           '--indent', '4',
           '--no-sort-keys',
         ]
-      #    -   id: requirements-txt-fixer
       - id: trailing-whitespace
-  #-   repo: meta
-  #    hooks:
-  #    -   id: check-hooks-apply
-  #    -   id: check-useless-excludes
+  -   repo: meta
+      hooks:
+      -   id: check-hooks-apply
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.3.0
+    hooks:
+      - id: reorder-python-imports
   - repo: https://github.com/pre-commit/mirrors-pylint
     rev: v1.9.1
     hooks:

--- a/cloudalerts/v1/loggers/__init__.py
+++ b/cloudalerts/v1/loggers/__init__.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
 from .alert_logging import AlertLogger
 from .cloud_logging import CloudLogging
 

--- a/cloudalerts/v2/loggers/logger.py
+++ b/cloudalerts/v2/loggers/logger.py
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+from typing import Any
+
+import structlog
+
+from cloudalerts.v2.loggers.structlog import setup
+
+LOGGER = None
+
+
+def get_log(app_name: str = None) -> Any:
+    """
+    This method either creates and returns or returns an instantiated
+    instance of an structured logger that reports to Stackdriver.
+    :param app_name:
+    :return: a global logger instance
+    """
+    global LOGGER
+    if not LOGGER:
+        setup(app_name)
+        LOGGER = structlog.get_logger()
+    return LOGGER

--- a/cloudalerts/v2/loggers/secops_formatter.py
+++ b/cloudalerts/v2/loggers/secops_formatter.py
@@ -1,0 +1,62 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import logging
+import socket
+
+
+# Modelled from:
+#   1. https://github.com/mozilla-services/python-dockerflow/blob/master/src/dockerflow/logging.py
+#   2. https://wiki.mozilla.org/Firefox/Services/Logging
+
+
+class SecOpsFormatter(logging.Formatter):
+    """Custom stdlib logging formatter for structlog ``event_dict`` messages.
+    Apply a structlog processor to the ``event_dict`` passed as
+    ``LogRecord.msg`` to convert it to loggable format (a string).
+    """
+
+    def __init__(self, processor, fmt=None, datefmt=None, style="%"):
+        """"""
+        super().__init__(fmt=fmt, datefmt=datefmt, style=style)
+        self.processor = processor
+
+    def format(self, record):
+        """Extract structlog's ``event_dict`` from ``record.msg``.
+        Process a copy of ``record.msg`` since the some processors modify the
+        ``event_dict`` and the ``LogRecord`` will be used for multiple
+        formatting runs.
+        """
+        if isinstance(record.msg, dict):
+            msg_repr = self.processor(record._logger, record._name, record.msg.copy())
+        return msg_repr
+
+
+def add_type_processor(logger, method_name, event_dict):
+    event_dict["Type"] = "request.summary"
+    return event_dict
+
+
+def add_hostname_processor(logger, method_name, event_dict):
+    event_dict["Host"] = socket.gethostname()
+    return event_dict
+
+
+def add_pid_processor(logger, method_name, event_dict):
+    event_dict["Pid"] = None
+    return event_dict
+
+
+def add_env_version_processor(logger, method_name, event_dict):
+    event_dict["EnvVersion"] = ""
+    return event_dict
+
+
+def add_severity_processor(logger, method_name, event_dict):
+    if "level" in event_dict:
+        event_dict["Severity"] = event_dict["level"]
+    return event_dict
+
+
+def event_dict_to_message(logger, name, event_dict):
+    return ((event_dict,), {"extra": {"_logger": logger, "_name": name}})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ url = "https://dp2-prod.appspot.com/pypi"
 
 [tool.poetry]
 name = "cloudalerts"
-version = "0.0.5"
+version = "0.0.6"
 description = "Python tool for accessing mozilla cloud alerting services."
 authors = [
     "Adam Frank <afrank@mozilla.com>",

--- a/tests/unit/cloudalerts/v2/loggers/test_secops_formatter.py
+++ b/tests/unit/cloudalerts/v2/loggers/test_secops_formatter.py
@@ -1,0 +1,90 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+import json
+import logging
+import sys
+import tempfile
+
+import structlog
+
+from cloudalerts.v2.loggers.secops_formatter import add_env_version_processor
+from cloudalerts.v2.loggers.secops_formatter import add_hostname_processor
+from cloudalerts.v2.loggers.secops_formatter import add_pid_processor
+from cloudalerts.v2.loggers.secops_formatter import add_severity_processor
+from cloudalerts.v2.loggers.secops_formatter import add_type_processor
+from cloudalerts.v2.loggers.secops_formatter import event_dict_to_message
+from cloudalerts.v2.loggers.secops_formatter import SecOpsFormatter
+
+
+def test_logging():
+    # Preamble
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            add_type_processor,
+            add_hostname_processor,
+            add_pid_processor,
+            add_env_version_processor,
+            add_severity_processor,
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            # Do not include last processor that converts to a string for stdlib
+            # since we leave that to the handler's formatter.
+            event_dict_to_message,
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    handler_stream = logging.StreamHandler(sys.stdout)
+    handler_stream.setFormatter(
+        SecOpsFormatter(processor=structlog.dev.ConsoleRenderer())
+    )
+    handler_stream.setLevel(logging.DEBUG)
+    tmpfile = tempfile.NamedTemporaryFile(delete=True)
+    temp_file_name = tmpfile.name
+    handler_file = logging.FileHandler(temp_file_name, encoding="utf-8")
+    handler_file.setLevel(logging.INFO)
+    handler_file.setFormatter(
+        SecOpsFormatter(processor=structlog.processors.JSONRenderer())
+    )
+
+    logger = structlog.get_logger("lib")
+    logger.setLevel(logging.DEBUG)
+
+    logging.root.setLevel(logging.WARNING)
+    logging.root.addHandler(handler_stream)
+    logging.root.addHandler(handler_file)
+
+    # Test
+    log = structlog.get_logger("lib")
+
+    # Log a few different events.
+    log.info("messageA")
+    log.info("messageB")
+    try:
+        raise AssertionError("critical")
+    except AssertionError as exc:
+        log.exception("some exception", exc=exc)
+
+    # Read the logfile, which contains one JSON string per entry.
+    with open(temp_file_name) as log:
+        log_json = log.read()
+    log = [json.loads(entry) for entry in log_json.splitlines()]
+    assert "messageA" in log[0]["event"]
+    assert "Host" in log[0]
+    assert "Pid" in log[0]
+    assert "Type" in log[0]
+    assert "Severity" in log[1]
+    assert "messageB" in log[1]["event"]
+    assert "Host" in log[1]
+    assert "Pid" in log[1]
+    assert "Severity" in log[1]
+    assert "Type" in log[1]


### PR DESCRIPTION
This pull request (PR) is a a feature to support the usage of the Mozilla (Firefox) security operations (SecOps) pipeline.  It is 1 of 2 parts and was separated such as it is part of work that I am seeking to do in my free-time.  The 2 parts of this work will seek to satisfy the goals of [this JIRA item](https://jira.mozilla.com/browse/INMA-40) for the logging library side and require a change to the application setup afterwards.  The standard for the SecOps logging format is available here:

https://wiki.mozilla.org/Firefox/Services/Logging

This PR seeks to add the headers and validate those rigorously with unit test coverage.  The unit test coverage for this addition is 100%.

```
py37 run-test: commands[2] | coverage report -m '--omit=*/test*,.tox/*' --show-missing --fail-under=45
Name                                         Stmts   Miss Branch BrPart     Cover   Missing
-------------------------------------------------------------------------------------------
cloudalerts/__init__.py                          1      0      0      0   100.00%
cloudalerts/v1/__init__.py                       0      0      0      0   100.00%
cloudalerts/v1/alerts/__init__.py                1      0      0      0   100.00%
cloudalerts/v1/alerts/alert_utils.py            41     25      4      0    35.56%   18-19, 23-25, 29-30, 34-35, 41-46, 55-64, 75-85
cloudalerts/v1/loggers/__init__.py               1      0      0      0   100.00%
cloudalerts/v1/loggers/alert_logging.py         30     15      2      0    46.88%   16-17, 29-36, 59-61, 64-66, 69
cloudalerts/v1/loggers/cloud_logging.py          2      0      0      0   100.00%
cloudalerts/v2/__init__.py                       0      0      0      0   100.00%
cloudalerts/v2/alerts/__init__.py                0      0      0      0   100.00%
cloudalerts/v2/alerts/alert_utils.py            26      3      2      1    85.71%   21, 40->41, 41-42
cloudalerts/v2/loggers/__init__.py               0      0      0      0   100.00%
cloudalerts/v2/loggers/log_filter.py            16      1     16      2    90.62%   15->16, 16, 19->18
cloudalerts/v2/loggers/logger.py                 5      5      2      0     0.00%   10-24
cloudalerts/v2/loggers/secops_formatter.py       7      0      0      0   100.00%
cloudalerts/v2/loggers/structlog.py             22     18      2      0    16.67%   22-42, 68, 101-103, 107-116
-------------------------------------------------------------------------------------------
TOTAL                                          152     67     28      3    55.56%

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-it/cloudalerts/31)
<!-- Reviewable:end -->
