### PR TITLE
Remove casing

### DIFF
--- a/cloudalerts/v2/loggers/structlog.py
+++ b/cloudalerts/v2/loggers/structlog.py
@@ -59,12 +59,6 @@ def monkeypatch_google_enqueue():
     _Worker.enqueue = decode_json_then_enqueue
 
 
-def event_uppercase(logger, method_name, event_dict):
-    if "event" in event_dict:
-        event_dict["event"] = event_dict["event"].upper()
-    return event_dict
-
-
 def configure_structlog():
     from structlog import processors, stdlib, threadlocal
 
@@ -79,8 +73,6 @@ def configure_structlog():
             stdlib.filter_by_level,
             # Adds logger=module_name (e.g __main__)
             stdlib.add_logger_name,
-            # Uppercase structlog's event name which shouldn't be convoluted with AWS events.
-            event_uppercase,
             # Censor secure data
             censor_header,
             # Allow for string interpolation

--- a/tests/unit/cloudalerts/v2/loggers/test_structlog.py
+++ b/tests/unit/cloudalerts/v2/loggers/test_structlog.py
@@ -3,15 +3,6 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-def test_event_uppercase():
-    from cloudalerts.v2.loggers.structlog import event_uppercase
-
-    event_dict = {"event": "lower"}
-    expected_dict = {"event": "LOWER"}
-    actual_dict = event_uppercase(None, None, event_dict)
-    assert expected_dict == actual_dict
-
-
 def test_configure_structlog():
     from cloudalerts.v2.loggers.structlog import configure_structlog
 


### PR DESCRIPTION
This pull request (PR) removes the event casing which is causing an issue in which the event is `None`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-it/cloudalerts/41)
<!-- Reviewable:end -->
